### PR TITLE
paco changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Version: 0.1.1
 Date: 2014-09-16
 Title: Procrustes application to cophylogenetic analysis
 Author: Juan Antonio Balbuena <ja.balbuena@uv.es>, Timothee Poisot
-    <t.poisot@gmail.com>
+    <t.poisot@gmail.com>, Matthew Hutchinson <matthewhutchinson15@gmail.com>
 Maintainer: Timothee Poisot <t.poisot@gmail.com>
 Depends:
     R (>= 3.0.0)

--- a/R/PACo.r
+++ b/R/PACo.r
@@ -31,7 +31,7 @@ PACo <- function(D, nperm=1000, seed=NA, margin=1)
         el[,margin] <- sample(el[,margin])
         try_again <- (length(unique(paste(el$Var1, el$Var2))) != Nlinks)
       }
-      permuted_HP <- reshape2::acast(el, Var1~Var2, length)
+      permuted_HP <- reshape2::acast(rbind(subset(reshape2::melt(D$HP), value==0),el), Var1~Var2, length)
       permuted_HP <- permuted_HP[rownames(D$HP),colnames(D$HP)]
       perm_D <- list(H=D$H, P=D$P, HP=permuted_HP)
       perm_paco <- add_pcoord(perm_D)

--- a/R/PACo.r
+++ b/R/PACo.r
@@ -35,5 +35,6 @@ PACo <- function(D, nperm=1000, seed=NA, method="r0")
    pvalue <- pvalue / nperm
    D$proc <- proc
    D$gof <- list(p=pvalue, ss=m2ss, n=nperm)
+   D$method <- method
    return(D)
 }

--- a/R/PACo.r
+++ b/R/PACo.r
@@ -2,7 +2,7 @@
 #' @param D a list with the data
 #' @param nperm Number of permutations
 #' @param seed Seed if results need to be reproduced
-#' @param margin The margin to sample (1 to sample rows, 2 to sample columns)
+#' @param method The method to permute matrices with: "r0", "r1", "r2", "c0", "swap", "quasiswap"
 #' @export
 #' @examples 
 #' data(gopherlice)
@@ -13,7 +13,7 @@
 #' D <- add_pcoord(D)
 #' D <- PACo(D, nperm=10, seed=42)
 #' print(D$gof)
-PACo <- function(D, nperm=1000, seed=NA, margin=1)
+PACo <- function(D, nperm=1000, seed=NA, method="NA")
 {
    if(!("H_PCo" %in% names(D))) D <- add_pcoord(D)
    proc <- vegan::procrustes(X=D$H_PCo, Y=D$P_PCo)
@@ -24,14 +24,7 @@ PACo <- function(D, nperm=1000, seed=NA, margin=1)
    if(!is.na(seed)) set.seed(seed)
    for(n in c(1:nperm))
    {
-      el <- subset(reshape2::melt(D$HP), value>0)
-      try_again = TRUE
-      while(try_again)
-      {
-        el[,margin] <- sample(el[,margin])
-        try_again <- (length(unique(paste(el$Var1, el$Var2))) != Nlinks)
-      }
-      permuted_HP <- reshape2::acast(rbind(subset(reshape2::melt(D$HP), value==0),el), Var1~Var2, length)
+      permuted_HP <- commsimulator(D$HP, method)
       permuted_HP <- permuted_HP[rownames(D$HP),colnames(D$HP)]
       perm_D <- list(H=D$H, P=D$P, HP=permuted_HP)
       perm_paco <- add_pcoord(perm_D)

--- a/R/PACo.r
+++ b/R/PACo.r
@@ -2,7 +2,7 @@
 #' @param D a list with the data
 #' @param nperm Number of permutations
 #' @param seed Seed if results need to be reproduced
-#' @param method The method to permute matrices with: "r0", "r1", "r2", "c0", "swap", "quasiswap"
+#' @param method The method to permute matrices with: "r0", "r1", "r2", "c0", "swap", "quasiswap", "backtrack", "tswap", "r00"
 #' @export
 #' @examples 
 #' data(gopherlice)
@@ -11,10 +11,11 @@
 #' ldist <- cophenetic(licetree)
 #' D <- prepare_paco_data(gdist, ldist, gl_links)
 #' D <- add_pcoord(D)
-#' D <- PACo(D, nperm=10, seed=42)
+#' D <- PACo(D, nperm=10, seed=42, method="r0")
 #' print(D$gof)
-PACo <- function(D, nperm=1000, seed=NA, method="NA")
+PACo <- function(D, nperm=1000, seed=NA, method="r0")
 {
+   method <- match.arg(method, c("r0", "r1", "r2", "r00", "c0", "swap", "tswap", "backtrack", "quasiswap"))
    if(!("H_PCo" %in% names(D))) D <- add_pcoord(D)
    proc <- vegan::procrustes(X=D$H_PCo, Y=D$P_PCo)
    Nlinks <- sum(D$HP)
@@ -24,7 +25,7 @@ PACo <- function(D, nperm=1000, seed=NA, method="NA")
    if(!is.na(seed)) set.seed(seed)
    for(n in c(1:nperm))
    {
-      permuted_HP <- commsimulator(D$HP, method)
+      permuted_HP <- vegan::commsimulator(D$HP, method)
       permuted_HP <- permuted_HP[rownames(D$HP),colnames(D$HP)]
       perm_D <- list(H=D$H, P=D$P, HP=permuted_HP)
       perm_paco <- add_pcoord(perm_D)

--- a/R/add_pcoord.r
+++ b/R/add_pcoord.r
@@ -9,12 +9,160 @@
 #' ldist <- cophenetic(licetree)
 #' D <- prepare_paco_data(gdist, ldist, gl_links)
 #' D <- add_pcoord(D)
+
 add_pcoord <- function(D)
 { 
    HP_bin <- which(D$HP > 0, arr.ind=TRUE)
-   H_PCo <- ape::pcoa(D$H, correction="cailliez")$vectors #Performs PCo of Host distances 
-   P_PCo <- ape::pcoa(D$P, correction="cailliez")$vectors #Performs PCo of Parasite distances
+   H_PCo <- coordpcoa(D$H, correction="cailliez")$vectors #Performs PCo of Host distances 
+   P_PCo <- coordpcoa(D$P, correction="cailliez")$vectors #Performs PCo of Parasite distances
    D$H_PCo <- H_PCo[HP_bin[,1],] #Adjust Host PCo vectors 
    D$P_PCo <- P_PCo[HP_bin[,2],]  #Adjust Parasite PCo vectors
    return(D)
+}
+
+coordpcoa <-function (D, correction = "none", rn = NULL) 
+{
+    centre <- function(D, n) {
+        One <- matrix(1, n, n)
+        mat <- diag(n) - One/n
+        mat.cen <- mat %*% D %*% mat
+    }
+    bstick.def <- function(n, tot.var = 1, ...) {
+        res <- rev(cumsum(tot.var/n:1)/n)
+        names(res) <- paste("Stick", seq(len = n), sep = "")
+        return(res)
+    }
+    D <- as.matrix(D)
+    n <- nrow(D)
+    epsilon <- sqrt(.Machine$double.eps)
+    if (length(rn) != 0) {
+        names <- rn
+    }
+    else {
+        names <- rownames(D)
+    }
+    CORRECTIONS <- c("none", "lingoes", "cailliez")
+    correct <- pmatch(correction, CORRECTIONS)
+    if (is.na(correct)) 
+        stop("Invalid correction method")
+    delta1 <- centre((-0.5 * D^2), n)
+    trace <- sum(diag(delta1))
+    D.eig <- eigen(delta1)
+    min.eig <- min(D.eig$values)
+    zero.eig <- which(abs(D.eig$values)- epsilon < epsilon)
+    D.eig$values[zero.eig] <- 0
+    if (min.eig > -epsilon) {
+        correct <- 1
+        eig <- D.eig$values
+        k <- length(which(eig > epsilon))
+        rel.eig <- eig[1:k]/trace
+        cum.eig <- cumsum(rel.eig)
+        vectors <- sweep(D.eig$vectors[, 1:k], 2, sqrt(eig[1:k]), 
+            FUN = "*")
+        bs <- bstick.def(k)
+        cum.bs <- cumsum(bs)
+        res <- data.frame(eig[1:k], rel.eig, bs, cum.eig, cum.bs)
+        colnames(res) <- c("Eigenvalues", "Relative_eig", "Broken_stick", 
+            "Cumul_eig", "Cumul_br_stick")
+        rownames(res) <- 1:nrow(res)
+        rownames(vectors) <- names
+        colnames(vectors) <- colnames(vectors, do.NULL = FALSE, 
+            prefix = "Axis.")
+        note <- paste("There were no negative eigenvalues. No correction was applied")
+        out <- (list(correction = c(correction, correct), note = note, 
+            values = res, vectors = vectors, trace = trace))
+    }
+    else {
+        k <- n
+        eig <- D.eig$values
+        rel.eig <- eig/trace
+        rel.eig.cor <- (eig - min.eig)/(trace - (n - 1) * min.eig)
+        rel.eig.cor = c(rel.eig.cor[1:(zero.eig[1] - 1)], rel.eig.cor[(zero.eig[1] + 
+            1):n], 0)
+        cum.eig.cor <- cumsum(rel.eig.cor)
+        k2 <- length(which(eig > epsilon))
+        k3 <- length(which(rel.eig.cor > epsilon))
+        vectors <- sweep(D.eig$vectors[, 1:k2], 2, sqrt(eig[1:k2]), 
+            FUN = "*")
+        if ((correct == 2) | (correct == 3)) {
+            if (correct == 2) {
+                c1 <- -min.eig
+                note <- paste("Lingoes correction applied to negative eigenvalues: D' = -0.5*D^2 -", 
+                  c1, ", except diagonal elements")
+                D <- -0.5 * (D^2 + 2 * c1)
+            }
+            else if (correct == 3) {
+                delta2 <- centre((-0.5 * D), n)
+                upper <- cbind(matrix(0, n, n), 2 * delta1)
+                lower <- cbind(-diag(n), -4 * delta2)
+                sp.matrix <- rbind(upper, lower)
+                c2 <- max(Re(eigen(sp.matrix, symmetric = FALSE, 
+                  only.values = TRUE)$values))
+                note <- paste("Cailliez correction applied to negative eigenvalues: D' = -0.5*(D +", 
+                  c2, ")^2, except diagonal elements")
+                D <- -0.5 * (D + c2)^2
+            }
+            diag(D) <- 0
+            mat.cor <- centre(D, n)
+            toto.cor <- eigen(mat.cor)
+            trace.cor <- sum(diag(mat.cor))
+            min.eig.cor <- min(toto.cor$values)
+            zero.eig.cor <- which((toto.cor$values < epsilon) & 
+                (toto.cor$values > -epsilon))
+            toto.cor$values[zero.eig.cor] <- 0
+            if (min.eig.cor > -epsilon) {
+                eig.cor <- toto.cor$values
+                rel.eig.cor <- eig.cor[1:k]/trace.cor
+                cum.eig.cor <- cumsum(rel.eig.cor)
+                k2 <- length(which(eig.cor > epsilon))
+                vectors.cor <- sweep(toto.cor$vectors[, 1:k2], 
+                  2, sqrt(eig.cor[1:k2]), FUN = "*")
+                bs <- bstick.def(k2)
+                bs <- c(bs, rep(0, (k - k2)))
+                cum.bs <- cumsum(bs)
+            }
+            else {
+                if (correct == 2) 
+                  cat("Problem! Negative eigenvalues are still present after Lingoes", 
+                    "\n")
+                if (correct == 3) 
+                  cat("Problem! Negative eigenvalues are still present after Cailliez", 
+                    "\n")
+                rel.eig.cor <- cum.eig.cor <- bs <- cum.bs <- rep(NA, 
+                  n)
+                vectors.cor <- matrix(NA, n, 2)
+            }
+            res <- data.frame(eig[1:k], eig.cor[1:k], rel.eig.cor, 
+                bs, cum.eig.cor, cum.bs)
+            colnames(res) <- c("Eigenvalues", "Corr_eig", "Rel_corr_eig", 
+                "Broken_stick", "Cum_corr_eig", "Cum_br_stick")
+            rownames(res) <- 1:nrow(res)
+            rownames(vectors) <- names
+            colnames(vectors) <- colnames(vectors, do.NULL = FALSE, 
+                prefix = "Axis.")
+            out <- (list(correction = c(correction, correct), 
+                note = note, values = res, vectors = vectors, 
+                trace = trace, vectors.cor = vectors.cor, trace.cor = trace.cor))
+        }
+        else {
+            note <- "No correction was applied to the negative eigenvalues"
+            bs <- bstick.def(k3)
+            bs <- c(bs, rep(0, (k - k3)))
+            cum.bs <- cumsum(bs)
+            res <- data.frame(eig[1:k], rel.eig, rel.eig.cor, 
+                bs, cum.eig.cor, cum.bs)
+            colnames(res) <- c("Eigenvalues", "Relative_eig", 
+                "Rel_corr_eig", "Broken_stick", "Cum_corr_eig", 
+                "Cumul_br_stick")
+            rownames(res) <- 1:nrow(res)
+            rownames(vectors) <- names
+            colnames(vectors) <- colnames(vectors, do.NULL = FALSE, 
+                prefix = "Axis.")
+            out <- (list(correction = c(correction, correct), 
+                note = note, values = res, vectors = vectors, 
+                trace = trace))
+        }
+    }
+    class(out) <- "pcoa"
+    out
 }

--- a/R/add_pcoord.r
+++ b/R/add_pcoord.r
@@ -49,8 +49,8 @@ coordpcoa <-function (D, correction = "none", rn = NULL)
     trace <- sum(diag(delta1))
     D.eig <- eigen(delta1)
     min.eig <- min(D.eig$values)
-    zero.eig <- which(abs(D.eig$values)- epsilon < epsilon)
-    D.eig$values[zero.eig] <- 0
+    D.eig$values <- vegan::eigenvals(D.eig)
+    zero.eig <- which(D.eig$values < epsilon)
     if (min.eig > -epsilon) {
         correct <- 1
         eig <- D.eig$values
@@ -107,9 +107,10 @@ coordpcoa <-function (D, correction = "none", rn = NULL)
             toto.cor <- eigen(mat.cor)
             trace.cor <- sum(diag(mat.cor))
             min.eig.cor <- min(toto.cor$values)
+            toto.cor$values <- vegan::eigenvals(toto.cor)
             zero.eig.cor <- which((toto.cor$values < epsilon) & 
                 (toto.cor$values > -epsilon))
-            toto.cor$values[zero.eig.cor] <- 0
+            
             if (min.eig.cor > -epsilon) {
                 eig.cor <- toto.cor$values
                 rel.eig.cor <- eig.cor[1:k]/trace.cor

--- a/R/paco_links.r
+++ b/R/paco_links.r
@@ -13,7 +13,7 @@ paco_links <- function(D, ...)
    {
       HP_ind <- D$HP
       HP_ind[HP.ones[i,1],HP.ones[i,2]]=0
-      PACo.ind <- PACo(list(H=D$H, P=D$P, HP=HP_ind), ...)
+      PACo.ind <- PACo(list(H=D$H, P=D$P, HP=HP_ind), method=D$method, ...)
       Proc.ind <- vegan::procrustes(X=PACo.ind$H_PCo, Y=PACo.ind$P_PCo) 
       res.Proc.ind <- c(residuals(Proc.ind))
       res.Proc.ind <- append(res.Proc.ind, NA, after= i-1)


### PR DESCRIPTION
only major change is use of vegan::commsimulator in PACo and thus paco_links to speed up computation. add_pcoord changed to utilise a edited version of ape::pcoa (function coordpcoa) so zero eigenvalues can be assigned
