### PR TITLE
nperm times faster paco links

### DIFF
--- a/R/paco_links.r
+++ b/R/paco_links.r
@@ -52,8 +52,8 @@ paco_links <- function(D, .parallel = FALSE, .progress = "none", ...)
 single_paco_link <- function (D, HP.ones, i,...) {
   HP_ind <- D$HP
   HP_ind[HP.ones[i,1],HP.ones[i,2]]=0
-  PACo.ind <- PACo(list(H=D$H, P=D$P, HP=HP_ind), method=D$method, ...)
-  Proc.ind <- add_pcoord(list(H=D$H, P=D$P, HP=HP_ind)) 
+  PACo.ind <- add_pcoord(list(H=D$H, P=D$P, HP=HP_ind))
+  Proc.ind <- vegan::procrustes(X=PACo.ind$H_PCo, Y=PACo.ind$P_PCo) 
   res.Proc.ind <- c(residuals(Proc.ind))
   res.Proc.ind <- append(res.Proc.ind, NA, after= i-1)
 }

--- a/R/paco_links.r
+++ b/R/paco_links.r
@@ -53,7 +53,7 @@ single_paco_link <- function (D, HP.ones, i,...) {
   HP_ind <- D$HP
   HP_ind[HP.ones[i,1],HP.ones[i,2]]=0
   PACo.ind <- PACo(list(H=D$H, P=D$P, HP=HP_ind), method=D$method, ...)
-  Proc.ind <- vegan::procrustes(X=PACo.ind$H_PCo, Y=PACo.ind$P_PCo) 
+  Proc.ind <- add_pcoord(list(H=D$H, P=D$P, HP=HP_ind)) 
   res.Proc.ind <- c(residuals(Proc.ind))
   res.Proc.ind <- append(res.Proc.ind, NA, after= i-1)
 }

--- a/R/paco_links.r
+++ b/R/paco_links.r
@@ -2,10 +2,9 @@
 #' @param D A list returned by proc_analysis
 #' @param .parallel if \code{TRUE}, calculate the jacknife contribution in parallel using the backend provided by foreach
 #' @param .progress name of the progress bar to use, see \code{\link[plyr]{create_progress_bar}}. Options include "text" and "tk". It only works when \code{.parallel = FALSE}
-#' @param ... Additional arguments to be passed to PACo
 #' @return A list with added object jacknife, containing the mean and upper CI values for each link
 #' @export
-paco_links <- function(D, .parallel = FALSE, .progress = "none", ...)
+paco_links <- function(D, .parallel = FALSE, .progress = "none")
 {
    HP.ones <- which(D$HP > 0, arr.ind=TRUE)
    SQres.jackn <- matrix(rep(NA, sum(D$HP)^2), sum(D$HP))# empty matrix of jackknifed squared residuals
@@ -20,7 +19,7 @@ paco_links <- function(D, .parallel = FALSE, .progress = "none", ...)
    
    # In parallel
    if (.parallel & exists ("foreach")) {
-     foreach (i=1:nlinks, .combine = rbind) %dopar% single_paco_link (D, HP.ones, i, ...)
+     foreach (i=1:nlinks, .combine = rbind) %dopar% single_paco_link (D, HP.ones, i)
    } else {
    # In sequence 
      if (.parallel & !exists ("foreach")) warning ("No parallel backend registered. Executing sequentially instead.")
@@ -28,7 +27,7 @@ paco_links <- function(D, .parallel = FALSE, .progress = "none", ...)
      pb$init (nlinks)
      for(i in c(1:nlinks)) 
      {
-       res.Proc.ind <- single_paco_link (D, HP.ones, i, ...)
+       res.Proc.ind <- single_paco_link (D, HP.ones, i)
        SQres.jackn[i, ] <- res.Proc.ind   #Append residuals to matrix of jackknifed squared residuals
        pb$step ()
      } 
@@ -49,7 +48,7 @@ paco_links <- function(D, .parallel = FALSE, .progress = "none", ...)
 }
 
 #PACo setting the ith link = 0
-single_paco_link <- function (D, HP.ones, i,...) {
+single_paco_link <- function (D, HP.ones, i) {
   HP_ind <- D$HP
   HP_ind[HP.ones[i,1],HP.ones[i,2]]=0
   PACo.ind <- add_pcoord(list(H=D$H, P=D$P, HP=HP_ind))

--- a/man/paco_links.Rd
+++ b/man/paco_links.Rd
@@ -4,7 +4,7 @@
 \alias{paco_links}
 \title{Contribution of individual links}
 \usage{
-paco_links(D, .parallel = FALSE, .progress = "none", ...)
+paco_links(D, .parallel = FALSE, .progress = "none")
 }
 \arguments{
 \item{D}{A list returned by proc_analysis}
@@ -12,8 +12,6 @@ paco_links(D, .parallel = FALSE, .progress = "none", ...)
 \item{.parallel}{if \code{TRUE}, calculate the jacknife contribution in parallel using the backend provided by foreach}
 
 \item{.progress}{name of the progress bar to use, see \code{\link[plyr]{create_progress_bar}}. Options include "text" and "tk". It only works when \code{.parallel = FALSE}}
-
-\item{...}{Additional arguments to be passed to PACo}
 }
 \value{
 A list with added object jacknife, containing the mean and upper CI values for each link

--- a/tests/testthat/test-example-runs.R
+++ b/tests/testthat/test-example-runs.R
@@ -4,7 +4,7 @@ run_example <- function (H, P, HP) {
   D <- prepare_paco_data(H, P, HP)
   D <- add_pcoord(D)
   D <- PACo(D, nperm = 10, seed = 42, method="r0")
-  D <- paco_links (D, nperm = 10, seed = 42)
+  D <- paco_links (D)
 }
 
 test_that ("paco example works as expected", {

--- a/tests/testthat/test-residuals.R
+++ b/tests/testthat/test-residuals.R
@@ -4,7 +4,7 @@ run_example <- function (H, P, HP) {
   D <- prepare_paco_data(H, P, HP)
   D <- add_pcoord(D)
   D <- PACo(D, nperm = 10, seed = 42, method="r0")
-  D <- paco_links (D, nperm = 10, seed = 42)
+  D <- paco_links (D)
 }
 
 data(gopherlice)


### PR DESCRIPTION
Calling `PACo` in each interaction removal in `paco_links` is not necessary because we only need the principal coordinates of the distance matrices and the procrustes residuals. In `paco_links` we don't need the goodness of fit info created by the permutations in PACo (which takes a lot of time). 

With this change `paco_links` is _nperm_ times faster than it used to be. It also uses around _nperm_ times less memory. Both paco objects are identical. Also the lineprof output of both versions is shown below:

```
library (lineprof)
old_paco_links <- lineprof (paco_links (D, nperm = 1000, seed = 42))
new_paco_links <- lineprof (paco_links_2 (D, nperm = 1000, seed = 42))

> old_paco-links
    time    alloc  release     dups             ref                         src
1 13.815 20139.28 20126.29 25329083 paco_links.r#31 paco_links/single_paco_link
> new_paco-links
   time alloc release  dups               ref                             src
1 0.014 19.48       0 25722 paco_links_2.r#31 paco_links_2/single_paco_link_2

> identical (paco_links (D, nperm= 100, seed = 42),
             paco_links_2 (D, nperm= 100, seed = 42))
TRUE
```

I know. It doesn't look like much, but the difference is very large when analysing large networks. 
